### PR TITLE
chore(renovate): fix lookup for private ch.dboeckli Maven packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,6 +64,18 @@
             "enabled": false
         },
         {
+            "description": "Private dboeckli Maven packages on GitHub Packages",
+            "matchDatasources": [
+                "maven"
+            ],
+            "matchPackageNames": [
+                "/^ch\\.dboeckli\\./"
+            ],
+            "registryUrls": [
+                "https://maven.pkg.github.com/dboeckli/kbe-brewery-lib"
+            ]
+        },
+        {
             "matchCategories": [
                 "docker"
             ],


### PR DESCRIPTION
Fixes the Renovate dependency lookup warning for `ch.dboeckli.springframeworkguru.kbe.lib:kbe-brewery-lib` (no-result) by overriding `registryUrls` for private `ch.dboeckli.*` Maven packages to the canonical GitHub Packages URL of the publishing repo `kbe-brewery-lib`.

Reference: `spring-6-rest-mvc` PR #222.